### PR TITLE
Move-to-google-cloud

### DIFF
--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -35,7 +35,7 @@ resource "kubernetes_deployment_v1" "web_deployment" {
   ]
 
   spec {
-    replicas = 2
+    replicas = 1
 
     selector {
       match_labels = {
@@ -57,7 +57,12 @@ resource "kubernetes_deployment_v1" "web_deployment" {
           image_pull_policy = "Always"
 
           port {
-            container_port = 3000
+            container_port = 80
+          }
+
+          env {
+            name  = "NODE_ENV"
+            value = "production"
           }
         }
         image_pull_secrets {
@@ -81,8 +86,7 @@ resource "kubernetes_service_v1" "web_service" {
     }
 
     port {
-      port        = 80
-      target_port = 3000
+      port = 80
     }
 
     type = "LoadBalancer"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Deployment now runs on standard HTTP port (80) instead of port 3000.
  * Application configured to run in production mode.
  * Deployment scaled to single instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->